### PR TITLE
Added to RestInvocation.getHttpMethod() to allow creation fully secure H...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.iml
 *.iws
 target/
+.DS_Store

--- a/src/main/java/si/mazi/rescu/RestInvocation.java
+++ b/src/main/java/si/mazi/rescu/RestInvocation.java
@@ -220,6 +220,13 @@ public class RestInvocation implements Serializable {
     public String getQueryString() {
         return queryString;
     }
+    
+    /**
+     * @return The HTTP method used in this invocation e.g. GET or POST
+     */
+    public String getHttpMethod() {
+        return restMethodMetadata.httpMethod.toString();
+    }
 
     public RestMethodMetadata getRestMethodMetadata() {
         return restMethodMetadata;


### PR DESCRIPTION
Hi Matija I use an HMAC scheme with a REST api. The scheme includes the HTTP method in the signature. To make this possible, I added getHttpMethod() to RestInvocation.

I also added .DS_Store to .gitignore. I develop using OS X, and the Finder can create this file.

Hope you can pull.

Big thanks, Dominic
