### PR TITLE
Extended configuration options (HTTPS, Jackson, etc.) + bugfixes

### DIFF
--- a/src/main/java/si/mazi/rescu/ClientConfig.java
+++ b/src/main/java/si/mazi/rescu/ClientConfig.java
@@ -3,10 +3,27 @@ package si.mazi.rescu;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 import java.util.Map;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLSocketFactory;
 
 public class ClientConfig {
     private final Map<Class<? extends Annotation>, Params> paramsMap = new HashMap<Class<? extends Annotation>, Params>();
-
+    
+    private SSLSocketFactory sslSocketFactory = null;
+    private HostnameVerifier hostnameVerifier = null;
+    private JacksonConfigureListener jacksonConfigureListener = null;
+    private int httpReadTimeout;
+    private Integer proxyPort;
+    private String proxyHost;
+    private boolean ignoreHttpErrorCodes;
+    
+    public ClientConfig() {
+        httpReadTimeout = Config.getHttpReadTimeout();
+        proxyPort = Config.getProxyPort();
+        proxyHost = Config.getProxyHost();
+        ignoreHttpErrorCodes = Config.isIgnoreHttpErrorCodes();
+    }
+    
     public ClientConfig add(Class<? extends Annotation> paramType, String paramName, Object paramValue) {
         Params params = paramsMap.get(paramType);
         if (params == null) {
@@ -19,5 +36,117 @@ public class ClientConfig {
 
     public Map<Class<? extends Annotation>, Params> getParamsMap() {
         return paramsMap;
+    }
+    
+    /**
+     * Gets the override SSL socket factory for HttpsURLConnection
+     * used if HTTPS protocol is requested.
+     * 
+     * @return the sslSocketFactory
+     */
+    public SSLSocketFactory getSslSocketFactory() {
+        return sslSocketFactory;
+    }
+
+    /**
+     * Sets the override SSL socket factory for HttpsURLConnection
+     * used if HTTPS protocol is requested.
+     * 
+     * @param sslSocketFactory the sslSocketFactory to set
+     */
+    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+        this.sslSocketFactory = sslSocketFactory;
+    }
+
+    /**
+     * Gets the override hostname verifier for HttpsURLConnection
+     * used if HTTPS protocol is requested.
+     * 
+     * @return the hostnameVerifier
+     */
+    public HostnameVerifier getHostnameVerifier() {
+        return hostnameVerifier;
+    }
+
+    /**
+     * Sets the override hostname for HttpsURLConnection
+     * used if HTTPS protocol is requested.
+     * 
+     * @param hostnameVerifier the hostnameVerifier to set
+     */
+    public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
+        this.hostnameVerifier = hostnameVerifier;
+    }
+
+    /**
+     * @return the httpReadTimeout
+     */
+    public int getHttpReadTimeout() {
+        return httpReadTimeout;
+    }
+
+    /**
+     * @param httpReadTimeout the httpReadTimeout to set
+     */
+    public void setHttpReadTimeout(int httpReadTimeout) {
+        this.httpReadTimeout = httpReadTimeout;
+    }
+
+    /**
+     * @return the proxyPort
+     */
+    public Integer getProxyPort() {
+        return proxyPort;
+    }
+
+    /**
+     * @param proxyPort the proxyPort to set
+     */
+    public void setProxyPort(Integer proxyPort) {
+        this.proxyPort = proxyPort;
+    }
+
+    /**
+     * @return the proxyHost
+     */
+    public String getProxyHost() {
+        return proxyHost;
+    }
+
+    /**
+     * @param proxyHost the proxyHost to set
+     */
+    public void setProxyHost(String proxyHost) {
+        this.proxyHost = proxyHost;
+    }
+
+    /**
+     * @return the ignoreHttpErrorCodes
+     */
+    public boolean isIgnoreHttpErrorCodes() {
+        return ignoreHttpErrorCodes;
+    }
+
+    /**
+     * @param ignoreHttpErrorCodes the ignoreHttpErrorCodes to set
+     */
+    public void setIgnoreHttpErrorCodes(boolean ignoreHttpErrorCodes) {
+        this.ignoreHttpErrorCodes = ignoreHttpErrorCodes;
+    }
+
+    /**
+     * @return the jacksonConfigureListener
+     * @see JacksonConfigureListener
+     */
+    public JacksonConfigureListener getJacksonConfigureListener() {
+        return jacksonConfigureListener;
+    }
+
+    /**
+     * @param jacksonConfigureListener the jacksonConfigureListener to set
+     * @see JacksonConfigureListener
+     */
+    public void setJacksonConfigureListener(JacksonConfigureListener jacksonConfigureListener) {
+        this.jacksonConfigureListener = jacksonConfigureListener;
     }
 }

--- a/src/main/java/si/mazi/rescu/Config.java
+++ b/src/main/java/si/mazi/rescu/Config.java
@@ -13,6 +13,8 @@ import java.util.Properties;
  */
 class Config {
     public static final String RESCU_PROPERTIES = "rescu.properties";
+    
+    
 
     private static final Logger log = LoggerFactory.getLogger(Config.class);
 

--- a/src/main/java/si/mazi/rescu/JacksonConfigureListener.java
+++ b/src/main/java/si/mazi/rescu/JacksonConfigureListener.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Martin Zima (reddragcz).
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package si.mazi.rescu;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Provides hooks for additional configuration of the internally used
+ * JSON converter of Jackson library.
+ * 
+ * @author Martin Zima (reddragcz)
+ */
+public interface JacksonConfigureListener {
+    
+    /**
+     * Called during the construction of each REST proxy object,
+     * after setting the default or implied ObjectMapper properties.
+     * For example, the users might want to register modules with
+     * nonstandard (de)serializers now.
+     * 
+     * @param objectMapper
+     */
+    void configureObjectMapper(ObjectMapper objectMapper);
+}

--- a/src/main/java/si/mazi/rescu/Params.java
+++ b/src/main/java/si/mazi/rescu/Params.java
@@ -26,6 +26,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * <p>
@@ -119,7 +121,8 @@ public class Params implements Serializable {
             if (!isParamSet(paramName)) {
                 throw new IllegalArgumentException("The value of '" + paramName + "' path parameter was not specified.");
             }
-            path = path.replace("{" + paramName + "}", getParamValueAsString(paramName));
+            path = Pattern.compile("\\{" + paramName + "(:.+?)?\\}".toString()).matcher(
+                path).replaceAll(Matcher.quoteReplacement(getParamValueAsString(paramName).toString()));
         }
         return path;
     }

--- a/src/main/java/si/mazi/rescu/RestInvocation.java
+++ b/src/main/java/si/mazi/rescu/RestInvocation.java
@@ -96,8 +96,11 @@ public class RestInvocation implements Serializable {
 
         contentType = restMethodMetadata.contentType;
         methodPath = getPath(restMethodMetadata.methodPathTemplate);
+        
         path = restMethodMetadata.intfacePath;
         path = appendIfNotEmpty(path, methodPath, "/");
+        path = getPath(path);
+        
         queryString = this.paramsMap.get(QueryParam.class).asQueryString();
 
         invocationUrl = getInvocationUrl(restMethodMetadata.baseUrl, path, queryString);
@@ -151,8 +154,7 @@ public class RestInvocation implements Serializable {
         return url;
     }
 
-    public String getPath(String methodPath) {
-
+    public final String getPath(String methodPath) {
         return paramsMap.get(PathParam.class).applyToPath(methodPath);
     }
 

--- a/src/main/java/si/mazi/rescu/RestInvocation.java
+++ b/src/main/java/si/mazi/rescu/RestInvocation.java
@@ -97,9 +97,8 @@ public class RestInvocation implements Serializable {
         contentType = restMethodMetadata.contentType;
         methodPath = getPath(restMethodMetadata.methodPathTemplate);
         
-        path = restMethodMetadata.intfacePath;
+        path = getPath(restMethodMetadata.intfacePath);
         path = appendIfNotEmpty(path, methodPath, "/");
-        path = getPath(path);
         
         queryString = this.paramsMap.get(QueryParam.class).asQueryString();
 

--- a/src/main/java/si/mazi/rescu/RestInvocationHandler.java
+++ b/src/main/java/si/mazi/rescu/RestInvocationHandler.java
@@ -41,10 +41,21 @@ public class RestInvocationHandler implements InvocationHandler {
     private final Map<Method, RestMethodMetadata> cache = new HashMap<Method, RestMethodMetadata>();
 
     public RestInvocationHandler(Class<?> restInterface, String url, ClientConfig config) {
-        this.config = config;
         this.intfacePath = restInterface.getAnnotation(Path.class).value();
         this.baseUrl = url;
-        this.httpTemplate = new HttpTemplate();
+        
+        if (config != null) {
+            this.config = config;
+        }
+        else {
+            this.config = new ClientConfig(); //default config
+        }
+        
+        this.httpTemplate = new HttpTemplate(this.config.getJacksonConfigureListener(),
+                this.config.getHttpReadTimeout(),
+                this.config.isIgnoreHttpErrorCodes(),
+                this.config.getProxyHost(), this.config.getProxyPort(),
+                this.config.getSslSocketFactory(), this.config.getHostnameVerifier());
     }
 
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {

--- a/src/test/java/si/mazi/rescu/AnnotationUtilsTest.java
+++ b/src/test/java/si/mazi/rescu/AnnotationUtilsTest.java
@@ -41,10 +41,10 @@ public class AnnotationUtilsTest {
     @Test
     public void testGetFromMethodOrClass() throws Exception {
         Path path = AnnotationUtils.getFromMethodOrClass(ExampleService.class.getMethod("getTicker", String.class, String.class), Path.class);
-        assertThat("Wrong path.", path.value(), equalTo("{ident}_{currency}/ticker"));
+        assertThat("Wrong path.", path.value(), equalTo("{ident: [a-Z]+}_{currency}/ticker"));
 
         Path pathFromIntf = AnnotationUtils.getFromMethodOrClass(ExampleService.class.getMethod("getInfo", Long.class, Long.class), Path.class);
-        assertThat("Wrong path.", pathFromIntf.value(), equalTo("api/2"));
+        assertThat("Wrong path.", pathFromIntf.value(), equalTo("api/{version}"));
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/si/mazi/rescu/ExampleService.java
+++ b/src/test/java/si/mazi/rescu/ExampleService.java
@@ -32,7 +32,7 @@ import java.math.BigDecimal;
 /**
  * @author Matija Mazi
  */
-@Path("api/2")
+@Path("api/{version}")
 public interface ExampleService {
 
     @POST
@@ -48,7 +48,7 @@ public interface ExampleService {
     Object withdrawBitcoin(@PathParam("user") String user, @FormParam("password") String password, @QueryParam("amount") BigDecimal amount, @QueryParam("address") String address);
 
     @GET
-    @Path("{ident}_{currency}/ticker")
+    @Path("{ident: [a-Z]+}_{currency}/ticker")
     @Consumes(MediaType.APPLICATION_FORM_URLENCODED)
     Object getTicker(@PathParam("ident") String tradeableIdentifier, @PathParam("currency") String currency);
 

--- a/src/test/java/si/mazi/rescu/HttpTemplateTest.java
+++ b/src/test/java/si/mazi/rescu/HttpTemplateTest.java
@@ -53,7 +53,7 @@ public class HttpTemplateTest {
 
     @Test
     public void testReadInputStreamAsEncodedString() throws Exception {
-        HttpTemplate testObject = new HttpTemplate() {
+        HttpTemplate testObject = new HttpTemplate(null, 30000, false, null, null, null, null) {
             @Override String getResponseEncoding(URLConnection connection) { return "UTF-8"; }
             @Override boolean izGzipped(HttpURLConnection connection) { return false; }
         };
@@ -90,6 +90,7 @@ public class HttpTemplateTest {
         private final HttpURLConnection mockHttpURLConnection;
 
         public MockHttpTemplate(HttpURLConnection mockHttpURLConnection) {
+            super(null, 30000, false, null, null, null, null);
             this.mockHttpURLConnection = mockHttpURLConnection;
         }
 

--- a/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
+++ b/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
@@ -50,9 +50,12 @@ public class RestInvocationHandlerTest {
     @Test
     public void testInvoke() throws Exception {
 
-        TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, null);
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.add(PathParam.class, "version", 2);
+        
+        TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, clientConfig);
         ExampleService proxy = RestProxyFactory.createProxy(ExampleService.class, testHandler);
-
+        
         proxy.buy("john", "secret", new BigDecimal("3.14"), new BigDecimal("10.00"));
         assertRequestData(testHandler, Order.class, null, "https://example.com/api/2/buy/", HttpMethod.POST, "https://example.com", "api/2/buy/", "buy/", "", "user=john&password=secret&amount=3.14&price=10.00", FormParam.class, "user", "john");
 
@@ -73,19 +76,24 @@ public class RestInvocationHandlerTest {
     @Test
     public void testHttpBasicAuth() throws Exception {
 
-        TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, null);
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.add(PathParam.class, "version", 0);
+        
+        TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, clientConfig);
         ExampleService proxy = RestProxyFactory.createProxy(ExampleService.class, testHandler);
 
         BasicAuthCredentials credentials = new BasicAuthCredentials("Aladdin", "open sesame");
         proxy.testBasicAuth(credentials, 23);
         HashMap<String, String> authHeaders = new HashMap<String, String>();
         authHeaders.put("Authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==");
-        assertRequestData(testHandler, Object.class, authHeaders, "https://example.com/api/2/auth?param=23", HttpMethod.GET, "https://example.com", "api/2/auth", "auth", "param=23", null);
+        assertRequestData(testHandler, Object.class, authHeaders, "https://example.com/api/0/auth?param=23", HttpMethod.GET, "https://example.com", "api/0/auth", "auth", "param=23", null);
     }
 
     @Test
     public void testHttpBasicAuthWithConfig() throws Exception {
         ClientConfig config = ClientConfigUtil.addBasicAuthCredentials(new ClientConfig(), "Aladdin", "open sesame");
+        config.add(PathParam.class, "version", 2);
+        
         TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, config);
         ExampleService proxy = RestProxyFactory.createProxy(ExampleService.class, testHandler);
 


### PR DESCRIPTION
-Extended the configuration options with ability to set the properties per proxy instance (not globally), HTTPS verification overrides and Jackson configuration listeners.
-Fixed Path parameters replacing when using regex matchers in interface definitions.
-Path parameters are now correctly resolved from the class annotations too.
