### PR TITLE
Construct ObjectMapper once per RestInvocationHandler

### DIFF
--- a/src/main/java/si/mazi/rescu/HttpTemplate.java
+++ b/src/main/java/si/mazi/rescu/HttpTemplate.java
@@ -49,7 +49,7 @@ class HttpTemplate {
 
     private final Logger log = LoggerFactory.getLogger(HttpTemplate.class);
 
-    private ObjectMapper objectMapper;
+    private final ObjectMapper objectMapper;
 
     /**
      * Default request header fields
@@ -64,7 +64,7 @@ class HttpTemplate {
     /**
      * Constructor
      */
-    public HttpTemplate(JacksonConfigureListener jacksonConfigureListener,
+    public HttpTemplate(ObjectMapper objectMapper,
             int readTimeout, boolean ignoreHttpErrorCodes,
             String proxyHost, Integer proxyPort,
             SSLSocketFactory sslSocketFactory, HostnameVerifier hostnameVerifier) {
@@ -72,14 +72,14 @@ class HttpTemplate {
         this.ignoreHttpErrorCodes = ignoreHttpErrorCodes;
         this.sslSocketFactory = sslSocketFactory;
         this.hostnameVerifier = hostnameVerifier;
-        
-        objectMapper = new ObjectMapper();
-        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
-        if (jacksonConfigureListener != null) {
-            jacksonConfigureListener.configureObjectMapper(objectMapper);
+        if(objectMapper != null) {
+            this.objectMapper = objectMapper;
+        } else {
+            this.objectMapper = new ObjectMapper();
+            this.objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         }
-        
+
         defaultHttpHeaders.put("Accept-Charset", CHARSET_UTF_8);
         // defaultHttpHeaders.put("Content-Type", "application/x-www-form-urlencoded");
         defaultHttpHeaders.put("Accept", "application/json");

--- a/src/main/java/si/mazi/rescu/RestInvocation.java
+++ b/src/main/java/si/mazi/rescu/RestInvocation.java
@@ -45,8 +45,7 @@ public class RestInvocation implements Serializable {
     @SuppressWarnings("unchecked")
     protected static final List<Class<? extends Annotation>> PARAM_ANNOTATION_CLASSES = Arrays.asList(QueryParam.class, PathParam.class, FormParam.class, HeaderParam.class);
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
-
+    private final ObjectMapper objectMapper;
     private final Map<Class<? extends Annotation>, Params> paramsMap;
     private final List<Object> unannanotatedParams = new ArrayList<Object>();
 
@@ -58,7 +57,12 @@ public class RestInvocation implements Serializable {
 
     private RestMethodMetadata restMethodMetadata;
 
-    RestInvocation(RestMethodMetadata restMethodMetadata, Object[] args, Map<Class<? extends Annotation>, Params> defaultParamsMap) {
+    RestInvocation(ObjectMapper objectMapper, RestMethodMetadata restMethodMetadata, Object[] args, Map<Class<? extends Annotation>, Params> defaultParamsMap) {
+        if(objectMapper != null) {
+            this.objectMapper = objectMapper;
+        } else {
+            this.objectMapper = new ObjectMapper();
+        }
         this.restMethodMetadata = restMethodMetadata;
 
         paramsMap = new HashMap<Class<? extends Annotation>, Params>();
@@ -116,8 +120,13 @@ public class RestInvocation implements Serializable {
     }
 
     // todo: this is needed only for testing
-    public RestInvocation(Map<Class<? extends Annotation>, Params> paramsMap, String contentType) {
+    public RestInvocation(ObjectMapper objectMapper, Map<Class<? extends Annotation>, Params> paramsMap, String contentType) {
 
+        if(objectMapper != null) {
+            this.objectMapper = objectMapper;
+        } else {
+            this.objectMapper = new ObjectMapper();
+        }
         this.contentType = contentType;
         this.paramsMap = new LinkedHashMap<Class<? extends Annotation>, Params>(paramsMap);
     }

--- a/src/main/java/si/mazi/rescu/RestInvocationHandler.java
+++ b/src/main/java/si/mazi/rescu/RestInvocationHandler.java
@@ -21,6 +21,9 @@
  */
 package si.mazi.rescu;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import javax.ws.rs.Path;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
@@ -33,6 +36,7 @@ import java.util.Map;
  */
 public class RestInvocationHandler implements InvocationHandler {
 
+    private final ObjectMapper objectMapper;
     private final HttpTemplate httpTemplate;
     private final String intfacePath;
     private final String baseUrl;
@@ -50,8 +54,13 @@ public class RestInvocationHandler implements InvocationHandler {
         else {
             this.config = new ClientConfig(); //default config
         }
-        
-        this.httpTemplate = new HttpTemplate(this.config.getJacksonConfigureListener(),
+        objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        if (this.config.getJacksonConfigureListener() != null) {
+            this.config.getJacksonConfigureListener().configureObjectMapper(objectMapper);
+        }
+
+        this.httpTemplate = new HttpTemplate(objectMapper,
                 this.config.getHttpReadTimeout(),
                 this.config.isIgnoreHttpErrorCodes(),
                 this.config.getProxyHost(), this.config.getProxyPort(),
@@ -60,7 +69,7 @@ public class RestInvocationHandler implements InvocationHandler {
 
     public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
         RestMethodMetadata restMethodMetadata = getMetadata(method);
-        RestInvocation params = new RestInvocation(restMethodMetadata, args, config == null ? null : config.getParamsMap());
+        RestInvocation params = new RestInvocation(objectMapper, restMethodMetadata, args, config == null ? null : config.getParamsMap());
         return invokeHttp(params);
     }
 

--- a/src/test/java/si/mazi/rescu/HmacPostBodyDigestTest.java
+++ b/src/test/java/si/mazi/rescu/HmacPostBodyDigestTest.java
@@ -44,7 +44,7 @@ public class HmacPostBodyDigestTest {
         Map<Class<? extends Annotation>, Params> paramsMap = new HashMap<Class<? extends Annotation>, Params>();
         paramsMap.put(FormParam.class, Params.of("nonce", 1328626350245256L));
 
-        String restSign = HmacPostBodyDigest.createInstance(secretKey).digestParams(new RestInvocation(paramsMap, "application/x-www-form-urlencoded"));
+        String restSign = HmacPostBodyDigest.createInstance(secretKey).digestParams(new RestInvocation(null, paramsMap, "application/x-www-form-urlencoded"));
         log.debug("Rest-Sign    : " + restSign);
         String expectedResult = "eNjLVoVh6LVQfzgv7qFMCL48b5d2Qd1gvratXGA76W6+g46Jl9TNkiTCHks5sLXjfAQ1rGnvWxRHu6pYjC5FSQ==";
         log.debug("Expected-Sign: " + expectedResult);


### PR DESCRIPTION
This pull request is motivated by http://wiki.fasterxml.com/JacksonBestPracticesPerformance

Currently:
- a new instance of ObjectMapper is constructed for writing each request invocation.
- the Jackson configuration only applies to the ObjectMapper used to read

This pull request changes things as follows:
- RestInvocationHandler is responsible for constructing an ObjectMapper and configuring it
- the same ObjectMapper is passed into HttpTemplate & RestInvocation

If you have concerns about this PR, please let me know what they are and I will try to address them. Thanks!
