### PR TITLE
Added HTTP connection timeouts

### DIFF
--- a/src/main/java/si/mazi/rescu/ClientConfig.java
+++ b/src/main/java/si/mazi/rescu/ClientConfig.java
@@ -14,12 +14,14 @@ public class ClientConfig {
     private SSLSocketFactory sslSocketFactory = null;
     private HostnameVerifier hostnameVerifier = null;
     private JacksonConfigureListener jacksonConfigureListener = null;
+    private int httpConnTimeout;
     private int httpReadTimeout;
     private Integer proxyPort;
     private String proxyHost;
     private boolean ignoreHttpErrorCodes;
     
     public ClientConfig() {
+        httpConnTimeout = Config.getHttpConnTimeout();
         httpReadTimeout = Config.getHttpReadTimeout();
         proxyPort = Config.getProxyPort();
         proxyHost = Config.getProxyHost();
@@ -78,6 +80,20 @@ public class ClientConfig {
      */
     public void setHostnameVerifier(HostnameVerifier hostnameVerifier) {
         this.hostnameVerifier = hostnameVerifier;
+    }
+
+    /**
+     * @return the httpConnTimeout
+     */
+    public int getHttpConnTimeout() {
+        return httpConnTimeout;
+    }
+
+    /**
+     * @param httpConnTimeout the httpConnTimeout to set
+     */
+    public void setHttpConnTimeout(int httpConnTimeout) {
+        this.httpConnTimeout = httpConnTimeout;
     }
 
     /**

--- a/src/main/java/si/mazi/rescu/Config.java
+++ b/src/main/java/si/mazi/rescu/Config.java
@@ -17,6 +17,8 @@ class Config {
     
 
     private static final Logger log = LoggerFactory.getLogger(Config.class);
+    
+    private static final String HTTP_CONN_TIMEOUT = "rescu.http.connTimeoutMillis";
 
     private static final String HTTP_READ_TIMEOUT = "rescu.http.readTimeoutMillis";
 
@@ -25,6 +27,8 @@ class Config {
     private static final String PROXY_PORT = "rescu.http.readProxyPort";
 
     private static final String IGNORE_HTTP_ERROR_CODES = "rescu.http.ignoreErrorCodes";
+
+    private static final int httpConnTimeout;
 
     private static final int httpReadTimeout;
 
@@ -36,7 +40,8 @@ class Config {
 
     static {
         Properties dfts = new Properties();
-        dfts.setProperty(HTTP_READ_TIMEOUT, "30000");
+        dfts.setProperty(HTTP_CONN_TIMEOUT, "30000"); //default 30s
+        dfts.setProperty(HTTP_READ_TIMEOUT, "30000"); //default 30s
 
         Properties properties = new Properties(dfts);
         InputStream propsStream = RestProxyFactory.class.getResourceAsStream("/rescu.properties");
@@ -49,6 +54,7 @@ class Config {
             }
         }
 
+        httpConnTimeout = Integer.parseInt(properties.getProperty(HTTP_CONN_TIMEOUT));
         httpReadTimeout = Integer.parseInt(properties.getProperty(HTTP_READ_TIMEOUT));
         proxyHost = properties.getProperty(PROXY_HOST);
         String proxyPortStr = properties.getProperty(PROXY_PORT);
@@ -57,10 +63,15 @@ class Config {
         ignoreHttpErrorCodes = ignoreErrorCodes == null ? false : Boolean.parseBoolean(ignoreErrorCodes);
 
         log.debug("Configuration from rescu.properties:");
+        log.debug("httpConnTimeout = {}", httpConnTimeout);
         log.debug("httpReadTimeout = {}", httpReadTimeout);
         log.debug("proxyHost = {}", proxyHost);
         log.debug("proxyPort = {}", proxyPort);
         log.debug("ignoreHttpErrorCodes = {}", ignoreHttpErrorCodes);
+    }
+
+    public static int getHttpConnTimeout() {
+        return httpConnTimeout;
     }
 
     public static int getHttpReadTimeout() {

--- a/src/main/java/si/mazi/rescu/HttpTemplate.java
+++ b/src/main/java/si/mazi/rescu/HttpTemplate.java
@@ -52,16 +52,27 @@ class HttpTemplate {
      * Default request header fields
      */
     private final Map<String, String> defaultHttpHeaders = new HashMap<String, String>();
+    private final int connTimeout;
     private final int readTimeout;
     private final Proxy proxy;
     private final SSLSocketFactory sslSocketFactory;
     private final HostnameVerifier hostnameVerifier;
+
 
     /**
      * Constructor
      */
     public HttpTemplate(int readTimeout, String proxyHost, Integer proxyPort,
             SSLSocketFactory sslSocketFactory, HostnameVerifier hostnameVerifier) {
+      this(0, readTimeout, proxyHost, proxyPort, sslSocketFactory, hostnameVerifier);
+    }
+    
+    /**
+     * Constructor
+     */
+    public HttpTemplate(int connTimeout,int readTimeout, String proxyHost, Integer proxyPort,
+            SSLSocketFactory sslSocketFactory, HostnameVerifier hostnameVerifier) {
+        this.connTimeout = connTimeout;
         this.readTimeout = readTimeout;
         this.sslSocketFactory = sslSocketFactory;
         this.hostnameVerifier = hostnameVerifier;
@@ -168,9 +179,12 @@ class HttpTemplate {
 
     protected HttpURLConnection getHttpURLConnection(String urlString) throws IOException {
         HttpURLConnection connection = (HttpURLConnection) new URL(urlString).openConnection(proxy);
-        
+
         if (readTimeout > 0) {
             connection.setReadTimeout(readTimeout);
+        }
+        if (connTimeout > 0) {
+          connection.setConnectTimeout(connTimeout);
         }
         
         if (connection instanceof HttpsURLConnection) {

--- a/src/main/java/si/mazi/rescu/RestInvocationHandler.java
+++ b/src/main/java/si/mazi/rescu/RestInvocationHandler.java
@@ -74,6 +74,7 @@ public class RestInvocationHandler implements InvocationHandler {
         
         //setup http client
         this.httpTemplate = new HttpTemplate(
+                this.config.getHttpConnTimeout(),
                 this.config.getHttpReadTimeout(),
                 this.config.getProxyHost(), this.config.getProxyPort(),
                 this.config.getSslSocketFactory(), this.config.getHostnameVerifier());


### PR DESCRIPTION
I've added the option for connection timeouts. I've noticed that most of my HTTP problems come in the connection phase, rather than in the read phase. 

I also didn't find any tests that are affected by this. Have I missed anything?

Follow up from #31 
