### PR TITLE
content length fix

### DIFF
--- a/src/main/java/si/mazi/rescu/HttpTemplate.java
+++ b/src/main/java/si/mazi/rescu/HttpTemplate.java
@@ -115,7 +115,7 @@ class HttpTemplate {
             httpHeaders.put("Content-Type", contentType);
         }
 
-        int contentLength = requestBody == null ? 0 : requestBody.length();
+        int contentLength = requestBody == null ? 0 : requestBody.getBytes().length;
         HttpURLConnection connection = configureURLConnection(method, urlString, httpHeaders, contentLength);
 
         if (contentLength > 0) {


### PR DESCRIPTION
String length is the number of unicode characters, which doesn`t match content length in bytes. This mismatch caused content-length related errors while posting characters above ASCII.
