### PR TITLE
Specify openjdk6 in travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,13 @@ language: java
 jdk:
   - openjdk6
 before_install: "git clone -b travis `git config --get remote.origin.url` target/travis"
-script: "mvn deploy --settings target/travis/settings.xml"
+script: "
+if [ ${TRAVIS_PULL_REQUEST} = 'false' ];
+then
+  mvn deploy --settings target/travis/settings.xml;
+else
+  mvn clean verify --settings target/travis/settings.xml;
+fi"
 
 # whitelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - openjdk6
 before_install: "git clone -b travis `git config --get remote.origin.url` target/travis"
 script: "mvn deploy --settings target/travis/settings.xml"
 


### PR DESCRIPTION
So that it will use Java 1.6(ideally, we should use Java 1.5 as same as we specified in maven-compiler-plugin in pom.xml, but Travis does not have JDK 1.5) in deploying snapshots to maven repository, otherwise it will use Oracle JDK 7 which is the current default JDK of Travis, and then XChange will get the following error as the class is since Java 1.7, but XChange is using JDK 1.6.

Exception in thread "main" java.lang.NoClassDefFoundError: java/lang/ReflectiveOperationException
