### PR TITLE
Strip byte order mark

### DIFF
--- a/src/main/java/si/mazi/rescu/HttpTemplate.java
+++ b/src/main/java/si/mazi/rescu/HttpTemplate.java
@@ -132,7 +132,7 @@ class HttpTemplate {
 
         InputStream inputStream = !HttpUtils.isErrorStatusCode(httpStatus) ?
             connection.getInputStream() : connection.getErrorStream();
-        String responseString = readInputStreamAsEncodedString(inputStream, connection);
+        String responseString = readInputStreamAsEncodedString(inputStream, connection).replace("\uFEFF", "");
         log.trace("Http call returned {}; response body:\n{}", httpStatus, responseString);
 
         return new InvocationResult(responseString, httpStatus);


### PR DESCRIPTION
JSON response by some servers added an unnecessary byte order mark which
would cause Jackson to throw an exception. This commit strips the
character from the response string before creating the InvocationResult.
