### PR TITLE
remove generics fromValueFactory

### DIFF
--- a/src/main/java/si/mazi/rescu/SynchronizedValueFactory.java
+++ b/src/main/java/si/mazi/rescu/SynchronizedValueFactory.java
@@ -28,6 +28,6 @@ package si.mazi.rescu;
  *
  * @author Rafał Krupiński
  */
-public interface SynchronizedValueFactory<T> {
-    T createValue();
+public interface SynchronizedValueFactory {
+    long createValue();
 }

--- a/src/test/java/si/mazi/rescu/ConstantValueFactory.java
+++ b/src/test/java/si/mazi/rescu/ConstantValueFactory.java
@@ -24,14 +24,14 @@ package si.mazi.rescu;
 /**
  * @author Rafał Krupiński
  */
-public class ConstantValueFactory<T> implements SynchronizedValueFactory<T> {
-    private T value;
+public class ConstantValueFactory<T> implements SynchronizedValueFactory {
+    private long value;
 
-    public ConstantValueFactory(T value) {
+    public ConstantValueFactory(long value) {
         this.value = value;
     }
 
-    public T createValue() {
+    public long createValue() {
         return value;
     }
 }

--- a/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
+++ b/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
@@ -248,7 +248,7 @@ public class RestInvocationHandlerTest {
     public void testValueGenerator()  {
         TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, new ClientConfig(), "OK", 200);
         ExampleService proxy = RestProxyFactory.createProxy(ExampleService.class, testHandler);
-        proxy.getNonce(new ConstantValueFactory<Long>(1L));
+        proxy.getNonce(new ConstantValueFactory(1L));
     }
 
     @Test

--- a/src/test/java/si/mazi/rescu/RestInvocationTest.java
+++ b/src/test/java/si/mazi/rescu/RestInvocationTest.java
@@ -72,7 +72,7 @@ public class RestInvocationTest {
     @Test
     public void testCreateWithValueGenerator() {
         Map<Class<? extends Annotation>, Params> paramsMap = new HashMap<Class<? extends Annotation>, Params>();
-        paramsMap.put(FormParam.class, Params.of("nonce", new ConstantValueFactory<Long>(nonce)));
+        paramsMap.put(FormParam.class, Params.of("nonce", new ConstantValueFactory(nonce)));
 
         RequestWriterResolver requestWriterResolver = new RequestWriterResolver();
         requestWriterResolver.addWriter(MediaType.APPLICATION_FORM_URLENCODED, new FormUrlEncodedRequestWriter());


### PR DESCRIPTION
I want to refactor XChange to make it easier to integrate nonce creation using Rescu's valueFactory. To do so, I will add a method to the `Xchange` interface: `SynchronizedValueFactory getNonceFactory();`. I want to get rid of the generics because otherwise, I need to pollute the entire Exchange hierarchy and implementation classes (and all constructors) with `<Long>` or `<N>`. And there's really no reason to not just hard code it to a long, as I did in this PR.
