### PR TITLE
squid:CommentedOutCodeLine, squid:S1941 - Multiple quality improvements

### DIFF
--- a/src/main/java/si/mazi/rescu/HttpTemplate.java
+++ b/src/main/java/si/mazi/rescu/HttpTemplate.java
@@ -74,7 +74,6 @@ class HttpTemplate {
         this.oAuthConsumer = oAuthConsumer;
 
         defaultHttpHeaders.put("Accept-Charset", CHARSET_UTF_8);
-        // defaultHttpHeaders.put("Content-Type", "application/x-www-form-urlencoded");
         defaultHttpHeaders.put("Accept", "application/json");
         // User agent provides statistics for servers, but some use it for content negotiation so fake good agents
         defaultHttpHeaders.put("User-Agent", "ResCU JDK/6 AppleWebKit/535.7 Chrome/16.0.912.36 Safari/535.7"); // custom User-Agent

--- a/src/main/java/si/mazi/rescu/RequestWriterResolver.java
+++ b/src/main/java/si/mazi/rescu/RequestWriterResolver.java
@@ -49,7 +49,6 @@ public class RequestWriterResolver {
 
         String reqContentType = methodMetadata.getReqContentType();
         if (reqContentType == null) {
-            //throw new IllegalArgumentException("No media type specified; don't know how to create request body. Please specify the body media type using @javax.ws.rs.Consumes.");
             reqContentType = MediaType.APPLICATION_FORM_URLENCODED;
         }
         writer = writers.get(reqContentType);

--- a/src/main/java/si/mazi/rescu/RestInvocationHandler.java
+++ b/src/main/java/si/mazi/rescu/RestInvocationHandler.java
@@ -69,8 +69,6 @@ public class RestInvocationHandler implements InvocationHandler {
         JacksonMapper jacksonMapper = new JacksonMapper(config.getJacksonConfigureListener());
 
         requestWriterResolver = new RequestWriterResolver();
-        /*requestWriterResolver.addWriter(null,
-                new NullRequestWriter());*/
         requestWriterResolver.addWriter(MediaType.APPLICATION_FORM_URLENCODED,
                 new FormUrlEncodedRequestWriter());
         requestWriterResolver.addWriter(MediaType.APPLICATION_JSON,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules squid:CommentedOutCodeLine - Sections of code should not be "commented out"
squid:S1941 - Variables should not be declared before they are relevant

You can find more information about the issues here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1941

Please let me know if you have any questions.

M-Ezzat
