### PR TITLE
Cleanup - squid:S1312 - Loggers should be "private static final" and …

### DIFF
--- a/src/main/java/si/mazi/rescu/Config.java
+++ b/src/main/java/si/mazi/rescu/Config.java
@@ -38,7 +38,7 @@ final class Config {
     
     
 
-    private static final Logger log = LoggerFactory.getLogger(Config.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(Config.class);
     
     private static final String HTTP_CONN_TIMEOUT = "rescu.http.connTimeoutMillis";
 
@@ -74,7 +74,7 @@ final class Config {
         if (propsStream != null) {
             try {
                 properties.load(propsStream);
-                log.debug("Loaded properties from {}.", RESCU_PROPERTIES);
+                LOGGER.debug("Loaded properties from {}.", RESCU_PROPERTIES);
             } catch (IOException e) {
                 throw new RuntimeException("Error reading " + RESCU_PROPERTIES, e);
             }
@@ -88,12 +88,12 @@ final class Config {
         ignoreHttpErrorCodes = getBoolean(properties, IGNORE_HTTP_ERROR_CODES);
         wrapUnexpectedExceptions = getBoolean(properties, WRAP_UNEXPECTED_EXCEPTIONS);
 
-        log.debug("Configuration from rescu.properties:");
-        log.debug("httpConnTimeout = {}", httpConnTimeout);
-        log.debug("httpReadTimeout = {}", httpReadTimeout);
-        log.debug("proxyHost = {}", proxyHost);
-        log.debug("proxyPort = {}", proxyPort);
-        log.debug("ignoreHttpErrorCodes = {}", ignoreHttpErrorCodes);
+        LOGGER.debug("Configuration from rescu.properties:");
+        LOGGER.debug("httpConnTimeout = {}", httpConnTimeout);
+        LOGGER.debug("httpReadTimeout = {}", httpReadTimeout);
+        LOGGER.debug("proxyHost = {}", proxyHost);
+        LOGGER.debug("proxyPort = {}", proxyPort);
+        LOGGER.debug("ignoreHttpErrorCodes = {}", ignoreHttpErrorCodes);
     }
 
     private Config() throws InstantiationException {

--- a/src/main/java/si/mazi/rescu/HttpTemplate.java
+++ b/src/main/java/si/mazi/rescu/HttpTemplate.java
@@ -46,7 +46,7 @@ class HttpTemplate {
 
     public final static String CHARSET_UTF_8 = "UTF-8";
 
-    private final Logger log = LoggerFactory.getLogger(HttpTemplate.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(HttpTemplate.class);
 
     /**
      * Default request header fields
@@ -83,14 +83,14 @@ class HttpTemplate {
             proxy = Proxy.NO_PROXY;
         } else {
             proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(proxyHost, proxyPort));
-            log.info("Using proxy {}", proxy);
+            LOGGER.info("Using proxy {}", proxy);
         }
     }
 
     HttpURLConnection send(String urlString, String requestBody, Map<String, String> httpHeaders, HttpMethod method) throws IOException {
-        log.debug("Executing {} request at {}", method, urlString);
-        log.trace("Request body = {}", requestBody);
-        log.trace("Request headers = {}", httpHeaders);
+        LOGGER.debug("Executing {} request at {}", method, urlString);
+        LOGGER.trace("Request body = {}", requestBody);
+        LOGGER.trace("Request headers = {}", httpHeaders);
 
         preconditionNotNull(urlString, "urlString cannot be null");
         preconditionNotNull(httpHeaders, "httpHeaders should not be null");
@@ -119,7 +119,7 @@ class HttpTemplate {
 
     InvocationResult receive(HttpURLConnection connection) throws IOException {
         int httpStatus = connection.getResponseCode();
-        log.debug("Request http status = {}", httpStatus);
+        LOGGER.debug("Request http status = {}", httpStatus);
 
         InputStream inputStream = !HttpUtils.isErrorStatusCode(httpStatus) ?
             connection.getInputStream() : connection.getErrorStream();
@@ -127,7 +127,7 @@ class HttpTemplate {
         if (responseString != null && responseString.startsWith("\uFEFF")) {
             responseString = responseString.substring(1);
         }
-        log.trace("Http call returned {}; response body:\n{}", httpStatus, responseString);
+        LOGGER.trace("Http call returned {}; response body:\n{}", httpStatus, responseString);
 
         return new InvocationResult(responseString, httpStatus);
     }
@@ -157,7 +157,7 @@ class HttpTemplate {
 
         for (Map.Entry<String, String> entry : headerKeyValues.entrySet()) {
             connection.setRequestProperty(entry.getKey(), entry.getValue());
-            log.trace("Header request property: key='{}', value='{}'", entry.getKey(), entry.getValue());
+            LOGGER.trace("Header request property: key='{}', value='{}'", entry.getKey(), entry.getValue());
         }
 
         // Perform additional configuration for POST

--- a/src/main/java/si/mazi/rescu/ResponseReader.java
+++ b/src/main/java/si/mazi/rescu/ResponseReader.java
@@ -38,7 +38,7 @@ import java.lang.reflect.Type;
  */
 public abstract class ResponseReader {
 
-    private static final Logger log = LoggerFactory.getLogger(ResponseReader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ResponseReader.class);
     public static final int BODY_FRAGMENT_CHARS = 100;
 
     private final boolean ignoreHttpErrorCodes;
@@ -69,7 +69,7 @@ public abstract class ResponseReader {
                         throw e;
                     }
                 }
-                log.debug("Parsing response as {} failed: {}", methodMetadata.getReturnType(), normalParseFailCause.toString());
+                LOGGER.debug("Parsing response as {} failed: {}", methodMetadata.getReturnType(), normalParseFailCause.toString());
             }
         }
 
@@ -81,7 +81,7 @@ public abstract class ResponseReader {
             try {
                 exception = readException(httpBody, methodMetadata.getExceptionType());
             } catch (Exception e) {
-                log.warn("Noncritical error parsing error output: " + Utils.clip(httpBody, BODY_FRAGMENT_CHARS), e);
+                LOGGER.warn("Noncritical error parsing error output: " + Utils.clip(httpBody, BODY_FRAGMENT_CHARS), e);
             }
 
             if (exception != null) {

--- a/src/main/java/si/mazi/rescu/RestInvocation.java
+++ b/src/main/java/si/mazi/rescu/RestInvocation.java
@@ -41,7 +41,7 @@ import java.util.*;
  * @author Matija Mazi
  */
 public class RestInvocation implements Serializable {
-    private static final Logger log = LoggerFactory.getLogger(RestInvocation.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestInvocation.class);
 
     @SuppressWarnings("unchecked")
     protected static final List<Class<? extends Annotation>> PARAM_ANNOTATION_CLASSES = Arrays.asList(QueryParam.class, PathParam.class, FormParam.class, HeaderParam.class);
@@ -144,7 +144,7 @@ public class RestInvocation implements Serializable {
 
         // Do some validation.
         if (!unannanotatedParams.isEmpty() && Arrays.asList(HttpMethod.DELETE, HttpMethod.GET).contains(methodMetadata.getHttpMethod())) {
-            log.warn("{} request will contain a body. While this is allowed, the body should be ignored by the server. Is this intended? Method: {}", methodMetadata.getHttpMethod(), methodMetadata.getMethodName());
+            LOGGER.warn("{} request will contain a body. While this is allowed, the body should be ignored by the server. Is this intended? Method: {}", methodMetadata.getHttpMethod(), methodMetadata.getMethodName());
         }
 
         return invocation;

--- a/src/main/java/si/mazi/rescu/RestInvocationHandler.java
+++ b/src/main/java/si/mazi/rescu/RestInvocationHandler.java
@@ -43,7 +43,7 @@ import java.util.Map;
  */
 public class RestInvocationHandler implements InvocationHandler {
 
-    private static final Logger log = LoggerFactory.getLogger(RestInvocationHandler.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestInvocationHandler.class);
 
     private final ResponseReaderResolver responseReaderResolver;
     private final RequestWriterResolver requestWriterResolver;
@@ -119,7 +119,7 @@ public class RestInvocationHandler implements InvocationHandler {
                     ((InvocationAware) e).setInvocation(invocation);
                     shouldWrap = false;
                 } catch (Exception ex) {
-                    log.warn("Failed to set invocation on the InvocationAware", ex);
+                    LOGGER.warn("Failed to set invocation on the InvocationAware", ex);
                 }
             }
             if (e instanceof HttpResponseAware && connection != null) {
@@ -127,7 +127,7 @@ public class RestInvocationHandler implements InvocationHandler {
                     ((HttpResponseAware) e).setResponseHeaders(connection.getHeaderFields());
                     shouldWrap = false;
                 } catch (Exception ex) {
-                    log.warn("Failed to set response headers on the HttpReponseAware", ex);
+                    LOGGER.warn("Failed to set response headers on the HttpReponseAware", ex);
                 }
             }
             if (shouldWrap) {

--- a/src/main/java/si/mazi/rescu/RestMethodMetadata.java
+++ b/src/main/java/si/mazi/rescu/RestMethodMetadata.java
@@ -41,7 +41,7 @@ import java.util.Map;
  */
 public class RestMethodMetadata implements Serializable {
 
-    private static final Logger log = LoggerFactory.getLogger(RestMethodMetadata.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(RestMethodMetadata.class);
 
     @SuppressWarnings("unchecked")
     private static final List<Class<? extends Annotation>> HTTP_METHOD_ANNS
@@ -108,7 +108,7 @@ public class RestMethodMetadata implements Serializable {
 
         // Do some validation.
         if (consumes != null && Arrays.asList(HttpMethod.DELETE, HttpMethod.GET).contains(httpMethod)) {
-            log.warn("{} request declared as consuming method body as {}. While body is allowed, it should be ignored by the server. Is this intended? Method: {}", httpMethod, reqContentType, method);
+            LOGGER.warn("{} request declared as consuming method body as {}. While body is allowed, it should be ignored by the server. Is this intended? Method: {}", httpMethod, reqContentType, method);
         }
 
         return new RestMethodMetadata(method.getGenericReturnType(), httpMethod,

--- a/src/main/java/si/mazi/rescu/serialization/PlainTextResponseReader.java
+++ b/src/main/java/si/mazi/rescu/serialization/PlainTextResponseReader.java
@@ -36,7 +36,7 @@ import java.lang.reflect.Type;
  * Returns the response body as a string.
  */
 public class PlainTextResponseReader extends ResponseReader {
-    private static final Logger log = LoggerFactory.getLogger(PlainTextResponseReader.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(PlainTextResponseReader.class);
 
     public PlainTextResponseReader(boolean ignoreHttpErrorCodes) {
         super(ignoreHttpErrorCodes);
@@ -68,13 +68,13 @@ public class PlainTextResponseReader extends ResponseReader {
             try {
                 // fallback to no-parameter constructor
                 constructedException = exceptionType.newInstance();
-                log.warn("Cannot construct a {} with message parameter. Ommiting the message, which was: {}", exceptionType, message);
+                LOGGER.warn("Cannot construct a {} with message parameter. Ommiting the message, which was: {}", exceptionType, message);
             } catch (IllegalAccessException | InstantiationException e) {
                 reflectiveOperationException = e;
             }
 
             if (reflectiveOperationException != null) {
-                log.warn("Cannot construct a {}. Throwing a RuntimeException instead. Main cause: {}", exceptionType, reflectiveOperationException.toString());
+                LOGGER.warn("Cannot construct a {}. Throwing a RuntimeException instead. Main cause: {}", exceptionType, reflectiveOperationException.toString());
                 throw new RuntimeException(message);
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1312 - Loggers should be "private static final" and should share a naming convention

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1312

Please let me know if you have any questions.

M-Ezzat
