### PR TITLE
Cleanup - squid:S1943 - Classes and methods that rely on the default …

### DIFF
--- a/src/main/java/si/mazi/rescu/HmacPostBodyDigest.java
+++ b/src/main/java/si/mazi/rescu/HmacPostBodyDigest.java
@@ -27,6 +27,7 @@ import javax.crypto.Mac;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 
@@ -53,7 +54,7 @@ public final class HmacPostBodyDigest implements ParamsDigest {
     private HmacPostBodyDigest(String secretKeyBase64) throws IllegalArgumentException {
 
         try {
-            SecretKey secretKey = new SecretKeySpec(Base64.decode(secretKeyBase64.getBytes()), HMAC_SHA_512);
+            SecretKey secretKey = new SecretKeySpec(Base64.decode(secretKeyBase64.getBytes(StandardCharsets.UTF_8)), HMAC_SHA_512);
             mac = Mac.getInstance(HMAC_SHA_512);
             mac.init(secretKey);
         } catch (IOException e) {
@@ -72,7 +73,7 @@ public final class HmacPostBodyDigest implements ParamsDigest {
 
     public String digestParams(RestInvocation restInvocation) {
 
-        mac.update(restInvocation.getRequestBody().getBytes());
+        mac.update(restInvocation.getRequestBody().getBytes(StandardCharsets.UTF_8));
         return Base64.encodeBytes(mac.doFinal()).trim();
     }
 }

--- a/src/main/java/si/mazi/rescu/HttpTemplate.java
+++ b/src/main/java/si/mazi/rescu/HttpTemplate.java
@@ -35,6 +35,7 @@ import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
 import java.io.*;
 import java.net.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.zip.GZIPInputStream;
@@ -216,7 +217,8 @@ class HttpTemplate {
             if (izGzipped(connection)) {
                 inputStream = new GZIPInputStream(inputStream);
             }
-            final InputStreamReader in = responseEncoding != null ? new InputStreamReader(inputStream, responseEncoding) : new InputStreamReader(inputStream);
+            final InputStreamReader in = responseEncoding != null ? new InputStreamReader(inputStream, responseEncoding)
+                    : new InputStreamReader(inputStream, StandardCharsets.UTF_8);
             reader = new BufferedReader(in);
             StringBuilder sb = new StringBuilder();
             for (String line; (line = reader.readLine()) != null; ) {

--- a/src/main/java/si/mazi/rescu/oauth/RescuOAuthRequestAdapter.java
+++ b/src/main/java/si/mazi/rescu/oauth/RescuOAuthRequestAdapter.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author Rafał Krupiński
@@ -20,6 +21,6 @@ public class RescuOAuthRequestAdapter extends HttpURLConnectionRequestAdapter {
 
     @Override
     public InputStream getMessagePayload() throws IOException {
-        return messagePayload != null ? new ByteArrayInputStream(messagePayload.getBytes()) : null;
+        return messagePayload != null ? new ByteArrayInputStream(messagePayload.getBytes(StandardCharsets.UTF_8)) : null;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1943 - Classes and methods that rely on the default system encoding should not be used

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943

Please let me know if you have any questions.

M-Ezzat
