### PR TITLE
Support PATCH try 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.github.mmazi</groupId>
     <artifactId>rescu</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.9.1-PATCH-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ResCU</name>
@@ -119,8 +119,8 @@
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
-            <artifactId>jsr311-api</artifactId>
-            <version>1.1.1</version>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <version>2.1</version>
         </dependency>
         <!-- JSR-305 annotations (@Nullable etc.) -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>com.github.mmazi</groupId>
     <artifactId>rescu</artifactId>
-    <version>1.9.1-PATCH-SNAPSHOT</version>
+    <version>1.9.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ResCU</name>
@@ -119,8 +119,8 @@
         </dependency>
         <dependency>
             <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
-            <version>2.1</version>
+            <artifactId>jsr311-api</artifactId>
+            <version>1.1.1</version>
         </dependency>
         <!-- JSR-305 annotations (@Nullable etc.) -->
         <dependency>

--- a/src/main/java/si/mazi/rescu/HttpMethod.java
+++ b/src/main/java/si/mazi/rescu/HttpMethod.java
@@ -25,5 +25,5 @@ package si.mazi.rescu;
  * @author Matija Mazi <br>
  */
 public enum HttpMethod {
-    GET, POST, PUT, DELETE, HEAD, OPTIONS
+    GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH
 }

--- a/src/main/java/si/mazi/rescu/RestMethodMetadata.java
+++ b/src/main/java/si/mazi/rescu/RestMethodMetadata.java
@@ -45,7 +45,7 @@ public class RestMethodMetadata implements Serializable {
 
     @SuppressWarnings("unchecked")
     private static final List<Class<? extends Annotation>> HTTP_METHOD_ANNS
-            = Arrays.asList(GET.class, POST.class, PUT.class, OPTIONS.class, HEAD.class, DELETE.class);
+            = Arrays.asList(GET.class, POST.class, PUT.class, OPTIONS.class, HEAD.class, DELETE.class, PATCH.class);
 
     private final Type returnType;
     private final HttpMethod httpMethod;

--- a/src/main/java/si/mazi/rescu/RestMethodMetadata.java
+++ b/src/main/java/si/mazi/rescu/RestMethodMetadata.java
@@ -34,6 +34,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
+import si.mazi.rescu.jaxrs.PATCH;
+
 /**
  * @author Matija Mazi
  *

--- a/src/main/java/si/mazi/rescu/RestProxyFactory.java
+++ b/src/main/java/si/mazi/rescu/RestProxyFactory.java
@@ -34,7 +34,7 @@ public final class RestProxyFactory {
 
     /**
      * Create a proxy implementation of restInterface. The interface must be annotated with jax-rs annotations. Basic support exists for {@link javax.ws.rs.Path}, {@link javax.ws.rs.GET},
-     * {@link javax.ws.rs.POST}, {@link javax.ws.rs.QueryParam}, {@link javax.ws.rs.FormParam}, {@link javax.ws.rs.HeaderParam}, {@link javax.ws.rs.PathParam}.
+     * {@link javax.ws.rs.POST}, {@link javax.ws.rs.QueryParam}, {@link javax.ws.rs.FormParam}, {@link javax.ws.rs.HeaderParam}, {@link javax.ws.rs.PathParam}., {@link javax.ws.rs.PATCH}
      *
      * @param restInterface The interface to implement
      * @param baseUrl       The service base baseUrl

--- a/src/main/java/si/mazi/rescu/RestProxyFactory.java
+++ b/src/main/java/si/mazi/rescu/RestProxyFactory.java
@@ -34,7 +34,7 @@ public final class RestProxyFactory {
 
     /**
      * Create a proxy implementation of restInterface. The interface must be annotated with jax-rs annotations. Basic support exists for {@link javax.ws.rs.Path}, {@link javax.ws.rs.GET},
-     * {@link javax.ws.rs.POST}, {@link javax.ws.rs.QueryParam}, {@link javax.ws.rs.FormParam}, {@link javax.ws.rs.HeaderParam}, {@link javax.ws.rs.PathParam}., {@link javax.ws.rs.PATCH}
+     * {@link javax.ws.rs.POST}, {@link javax.ws.rs.QueryParam}, {@link javax.ws.rs.FormParam}, {@link javax.ws.rs.HeaderParam}, {@link javax.ws.rs.PathParam}., {@link si.mazi.rescu.jaxrs.PATCH}
      *
      * @param restInterface The interface to implement
      * @param baseUrl       The service base baseUrl

--- a/src/main/java/si/mazi/rescu/jaxrs/PATCH.java
+++ b/src/main/java/si/mazi/rescu/jaxrs/PATCH.java
@@ -1,0 +1,15 @@
+package si.mazi.rescu.jaxrs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.ws.rs.HttpMethod;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@HttpMethod("PATCH")
+public @interface PATCH {
+
+}

--- a/src/test/java/si/mazi/rescu/ExampleService.java
+++ b/src/test/java/si/mazi/rescu/ExampleService.java
@@ -25,6 +25,7 @@ import si.mazi.rescu.dto.DummyAccountInfo;
 import si.mazi.rescu.dto.DummyTicker;
 import si.mazi.rescu.dto.GenericResult;
 import si.mazi.rescu.dto.Order;
+import si.mazi.rescu.jaxrs.PATCH;
 
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;

--- a/src/test/java/si/mazi/rescu/ExampleService.java
+++ b/src/test/java/si/mazi/rescu/ExampleService.java
@@ -91,6 +91,12 @@ public interface ExampleService {
     @Produces(MediaType.TEXT_PLAIN)
     String putNumber(int number);
 
+    @PATCH
+    @Path("number")
+    @Consumes(MediaType.TEXT_PLAIN)
+    @Produces(MediaType.TEXT_PLAIN)
+    String updateNumber(int number);
+
     @GET
     @Path("nonce")
     @Consumes(MediaType.TEXT_PLAIN)

--- a/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
+++ b/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
@@ -255,6 +255,14 @@ public class RestInvocationHandlerTest {
     }
 
     @Test
+    public void testPatchTextPlain() throws Exception {
+        TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, new ClientConfig(), "OK", 200);
+        ExampleService proxy = RestProxyFactory.createProxy(ExampleService.class, testHandler);
+        proxy.updateNumber(123456);
+        assertThat(testHandler.getInvocation().getRequestBody()).isEqualTo("123456");
+    }
+
+    @Test
     public void testValueGenerator()  {
         TestRestInvocationHandler testHandler = new TestRestInvocationHandler(ExampleService.class, new ClientConfig(), "OK", 200);
         ExampleService proxy = RestProxyFactory.createProxy(ExampleService.class, testHandler);


### PR DESCRIPTION
#95

@mmazi Reviewer



With this approach I get the following

```

java.net.ProtocolException: Invalid HTTP method: PATCH

	at java.net.HttpURLConnection.setRequestMethod(HttpURLConnection.java:428)
	at sun.net.www.protocol.https.HttpsURLConnectionImpl.setRequestMethod(HttpsURLConnectionImpl.java:374)
	at si.mazi.rescu.HttpTemplate.configureURLConnection(HttpTemplate.java:152)
	at si.mazi.rescu.HttpTemplate.send(HttpTemplate.java:99)
	at si.mazi.rescu.RestInvocationHandler.invokeHttp(RestInvocationHandler.java:152)


```
HttpURLConnection supports the following in 1.7

    private static final String[] methods = {
        "GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE"
    };

related
https://bugs.openjdk.java.net/browse/JDK-7016595


There is quite a bit on the web about this, including using reflection to get around the issue, but it is a hack. Alternatively some use the HttpClient from apache, but that may be quite a bit of work.. do you have any additional thoughts?
