### PR TITLE
Java interface for RestProxyFactory

### DIFF
--- a/src/main/java/si/mazi/rescu/IRestProxyFactory.java
+++ b/src/main/java/si/mazi/rescu/IRestProxyFactory.java
@@ -1,0 +1,16 @@
+package si.mazi.rescu;
+
+/**
+ * @see RestProxyFactory
+ */
+public interface IRestProxyFactory {
+  /**
+   * @see RestProxyFactory#createProxy(Class, String, ClientConfig, Interceptor...)
+   */
+  <I> I createProxy(Class<I> restInterface, String baseUrl, ClientConfig config, Interceptor... interceptors);
+
+  /**
+   * @see RestProxyFactory#createProxy(Class, String)
+   */
+  <I> I createProxy(Class<I> restInterface, String baseUrl);
+}

--- a/src/main/java/si/mazi/rescu/RestProxyFactoryImpl.java
+++ b/src/main/java/si/mazi/rescu/RestProxyFactoryImpl.java
@@ -1,0 +1,16 @@
+package si.mazi.rescu;
+
+/**
+ * The default implementation of {@link IRestProxyFactory} that calls {@link RestProxyFactory}
+ */
+public class RestProxyFactoryImpl implements IRestProxyFactory {
+  @Override
+  public <I> I createProxy(Class<I> restInterface, String baseUrl, ClientConfig config, Interceptor... interceptors) {
+    return RestProxyFactory.createProxy(restInterface, baseUrl, config, interceptors);
+  }
+
+  @Override
+  public <I> I createProxy(Class<I> restInterface, String baseUrl) {
+    return RestProxyFactory.createProxy(restInterface, baseUrl);
+  }
+}

--- a/src/test/java/si/mazi/rescu/RestProxyFactoryImplTest.java
+++ b/src/test/java/si/mazi/rescu/RestProxyFactoryImplTest.java
@@ -1,0 +1,24 @@
+package si.mazi.rescu;
+
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RestProxyFactoryImplTest {
+
+    @Test
+    public void testCreateProxy() {
+        IRestProxyFactory f = new RestProxyFactoryImpl();
+        ExampleService proxy = f.createProxy(ExampleService.class, "http://example.com/api");
+
+        assertThat(proxy).isNotNull();
+    }
+
+    @Test
+    public void testCreateProxy1() {
+        IRestProxyFactory f = new RestProxyFactoryImpl();
+        ExampleService proxy = f.createProxy(ExampleService.class, "http://example.com/api", new ClientConfig());
+
+        assertThat(proxy).isNotNull();
+    }
+}


### PR DESCRIPTION
Clients can use the interface instead of concrete class and then their tests can mock the IRestProxyFactory.

Related to [xchange#2337](https://github.com/timmolter/XChange/issues/2337)

This would help getting rid of PowerMockito, which use is generally discouraged and currently doesn't support Java9
