### PR TITLE
Use annotationType instead of getClass

### DIFF
--- a/src/main/java/si/mazi/rescu/AnnotationUtils.java
+++ b/src/main/java/si/mazi/rescu/AnnotationUtils.java
@@ -42,7 +42,7 @@ public final class AnnotationUtils {
             return null;
         }
         try {
-            return (String) ann.getClass().getMethod("value").invoke(ann);
+            return (String) ann.annotationType().getMethod("value").invoke(ann);
         } catch (Exception e) {
             throw new RuntimeException("Can't access element 'value' in  " + annotationClass + ". This is probably a bug in rescu.", e);
         }


### PR DESCRIPTION
Access type of annotation directly, not through the getClass() that creates a proxy. This allows for the library to be used seamlessly in GraalVM Native applications. 