### PR TITLE
Migrated from the javax to the jakarta namespace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>
-            <version>2.1.5</version>
+            <version>3.1.0</version>
         </dependency>
         <!-- JSR-305 annotations (@Nullable etc.) -->
         <dependency>

--- a/src/main/java/si/mazi/rescu/ClientConfigUtil.java
+++ b/src/main/java/si/mazi/rescu/ClientConfigUtil.java
@@ -23,7 +23,7 @@
 
 package si.mazi.rescu;
 
-import javax.ws.rs.HeaderParam;
+import jakarta.ws.rs.HeaderParam;
 import java.io.UnsupportedEncodingException;
 import java.util.Base64;
 

--- a/src/main/java/si/mazi/rescu/FormUrlEncodedRequestWriter.java
+++ b/src/main/java/si/mazi/rescu/FormUrlEncodedRequestWriter.java
@@ -23,8 +23,8 @@
  */
 package si.mazi.rescu;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Writes the @FormParam annotated data as URL-encoded string.

--- a/src/main/java/si/mazi/rescu/NullRequestWriter.java
+++ b/src/main/java/si/mazi/rescu/NullRequestWriter.java
@@ -24,7 +24,7 @@
 
 package si.mazi.rescu;
 
-import javax.ws.rs.FormParam;
+import jakarta.ws.rs.FormParam;
 
 /**
  *

--- a/src/main/java/si/mazi/rescu/RequestWriterResolver.java
+++ b/src/main/java/si/mazi/rescu/RequestWriterResolver.java
@@ -28,7 +28,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import si.mazi.rescu.serialization.ToStringRequestWriter;
 import si.mazi.rescu.serialization.jackson.JacksonRequestWriter;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.util.HashMap;
 
 /**

--- a/src/main/java/si/mazi/rescu/ResponseReaderResolver.java
+++ b/src/main/java/si/mazi/rescu/ResponseReaderResolver.java
@@ -24,7 +24,7 @@
 
 package si.mazi.rescu;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.util.HashMap;
 
 /**

--- a/src/main/java/si/mazi/rescu/RestInvocation.java
+++ b/src/main/java/si/mazi/rescu/RestInvocation.java
@@ -25,10 +25,10 @@ package si.mazi.rescu;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.*;

--- a/src/main/java/si/mazi/rescu/RestInvocationHandler.java
+++ b/src/main/java/si/mazi/rescu/RestInvocationHandler.java
@@ -29,8 +29,8 @@ import si.mazi.rescu.serialization.jackson.DefaultJacksonObjectMapperFactory;
 import si.mazi.rescu.serialization.jackson.JacksonObjectMapperFactory;
 import si.mazi.rescu.serialization.jackson.JacksonResponseReader;
 
-import javax.ws.rs.Path;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;

--- a/src/main/java/si/mazi/rescu/RestMethodMetadata.java
+++ b/src/main/java/si/mazi/rescu/RestMethodMetadata.java
@@ -24,7 +24,7 @@ package si.mazi.rescu;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.*;
+import jakarta.ws.rs.*;
 import java.io.IOException;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;

--- a/src/main/java/si/mazi/rescu/serialization/ToStringRequestWriter.java
+++ b/src/main/java/si/mazi/rescu/serialization/ToStringRequestWriter.java
@@ -26,9 +26,9 @@ package si.mazi.rescu.serialization;
 import si.mazi.rescu.RequestWriter;
 import si.mazi.rescu.RestInvocation;
 
-import javax.ws.rs.FormParam;
+import jakarta.ws.rs.FormParam;
 
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 
 /**
  * Writes the data as string using toString.

--- a/src/main/java/si/mazi/rescu/serialization/jackson/JacksonRequestWriter.java
+++ b/src/main/java/si/mazi/rescu/serialization/jackson/JacksonRequestWriter.java
@@ -28,8 +28,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import si.mazi.rescu.RequestWriter;
 import si.mazi.rescu.RestInvocation;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Writes the data as JSON-serialized string using Jackson.

--- a/src/test/java/si/mazi/rescu/AnnotationUtilsTest.java
+++ b/src/test/java/si/mazi/rescu/AnnotationUtilsTest.java
@@ -24,7 +24,7 @@ package si.mazi.rescu;
 import org.testng.annotations.Test;
 import si.mazi.rescu.dto.DummyAccountInfo;
 
-import javax.ws.rs.*;
+import jakarta.ws.rs.*;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.*;

--- a/src/test/java/si/mazi/rescu/ExampleService.java
+++ b/src/test/java/si/mazi/rescu/ExampleService.java
@@ -26,8 +26,8 @@ import si.mazi.rescu.dto.DummyTicker;
 import si.mazi.rescu.dto.GenericResult;
 import si.mazi.rescu.dto.Order;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Date;

--- a/src/test/java/si/mazi/rescu/ExampleService2.java
+++ b/src/test/java/si/mazi/rescu/ExampleService2.java
@@ -23,11 +23,11 @@ package si.mazi.rescu;
 
 import si.mazi.rescu.dto.Order;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * @author Matija Mazi

--- a/src/test/java/si/mazi/rescu/FormUrlEncodedRequestWriterTest.java
+++ b/src/test/java/si/mazi/rescu/FormUrlEncodedRequestWriterTest.java
@@ -26,8 +26,8 @@ package si.mazi.rescu;
 
 import org.testng.annotations.Test;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.core.MediaType;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/test/java/si/mazi/rescu/HmacPostBodyDigestTest.java
+++ b/src/test/java/si/mazi/rescu/HmacPostBodyDigestTest.java
@@ -26,8 +26,8 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.core.MediaType;
 import java.lang.annotation.Annotation;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;

--- a/src/test/java/si/mazi/rescu/InvocationDigestTest.java
+++ b/src/test/java/si/mazi/rescu/InvocationDigestTest.java
@@ -26,8 +26,8 @@ package si.mazi.rescu;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.testng.annotations.Test;
 
-import javax.ws.rs.*;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
 import java.util.HashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
+++ b/src/test/java/si/mazi/rescu/RestInvocationHandlerTest.java
@@ -34,11 +34,11 @@ import si.mazi.rescu.dto.DummyTicker;
 import si.mazi.rescu.dto.GenericResult;
 import si.mazi.rescu.dto.Order;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationHandler;

--- a/src/test/java/si/mazi/rescu/RestInvocationTest.java
+++ b/src/test/java/si/mazi/rescu/RestInvocationTest.java
@@ -29,10 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
 
-import javax.ws.rs.FormParam;
-import javax.ws.rs.HeaderParam;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.FormParam;
+import jakarta.ws.rs.HeaderParam;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
 import java.io.UnsupportedEncodingException;
 import java.lang.annotation.Annotation;
 import java.net.URLDecoder;

--- a/src/test/java/si/mazi/rescu/RootPathService.java
+++ b/src/test/java/si/mazi/rescu/RootPathService.java
@@ -21,9 +21,9 @@
  */
 package si.mazi.rescu;
 
-import javax.ws.rs.DELETE;
-import javax.ws.rs.Path;
-import javax.ws.rs.QueryParam;
+import jakarta.ws.rs.DELETE;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.QueryParam;
 
 
 /**

--- a/src/test/java/si/mazi/rescu/serialization/jackson/JacksonRequestWriterTest.java
+++ b/src/test/java/si/mazi/rescu/serialization/jackson/JacksonRequestWriterTest.java
@@ -32,7 +32,7 @@ import si.mazi.rescu.dto.DummyAccountInfo;
 import java.lang.annotation.Annotation;
 import java.util.HashMap;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON;
 import static org.testng.Assert.assertEquals;
 import static si.mazi.rescu.HttpMethod.GET;
 

--- a/src/test/java/si/mazi/rescu/serialization/jackson/JacksonResponseReaderTest.java
+++ b/src/test/java/si/mazi/rescu/serialization/jackson/JacksonResponseReaderTest.java
@@ -32,7 +32,7 @@ import si.mazi.rescu.*;
 import si.mazi.rescu.dto.DummyTicker;
 import si.mazi.rescu.dto.GenericResult;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 import java.lang.reflect.Type;
 import java.util.Map;
 


### PR DESCRIPTION
Hello,
First of all, thanks for providing and maintaining rescu!
In relation to #142 here's a pull request to use `jakarta.ws.rs`. The changes should be quite straightforward however this means that going forward rescu will not support `javax.ws.rs` anymore.
Maybe a `javax` maintenance branch could be created to keep publishing fix versions (e.g. if a security vulnerability is fixed)?